### PR TITLE
Feature rasterize retry

### DIFF
--- a/pdgraster/RasterTiler.py
+++ b/pdgraster/RasterTiler.py
@@ -176,7 +176,7 @@ class RasterTiler():
             morecantile.Tile or None
                 The tile that was rasterized or None if there was an error.
         """
-        for attempt in range(2):
+        for attempt in range(1):
             try:
 
                 # Get information about the tile from the path
@@ -221,14 +221,14 @@ class RasterTiler():
                 return tile
 
             except Exception as e:
-                logger.info(f'Error rasterizing {path} for tile {tile} so trying again.')
+                logger.info(f'Error rasterizing {path} for tile {tile} due to error {e} so trying again.')
 
             else:
                 break
                 
         else:
             message = f'Error rasterizing {path} for tile {tile}, ran out of retries.'
-            self.__end_tracking(id, tile=tile, error=e, message=message)
+            self.__end_tracking(id, tile=tile, message=message)
             return None
 
 

--- a/pdgraster/RasterTiler.py
+++ b/pdgraster/RasterTiler.py
@@ -176,6 +176,7 @@ class RasterTiler():
             morecantile.Tile or None
                 The tile that was rasterized or None if there was an error.
         """
+        # if first rasterization attempt fails, try again
         for attempt in range(1):
             try:
 
@@ -221,13 +222,14 @@ class RasterTiler():
                 return tile
 
             except Exception as e:
-                logger.info(f'Error rasterizing {path} for tile {tile} due to error {e} so trying again.')
+                logger.info(f'Error rasterizing {path} for tile {tile}'
+                            f' on first try due to Error:\t\n{e}, trying again.')
 
             else:
                 break
                 
         else:
-            message = f'Error rasterizing {path} for tile {tile}, ran out of retries.'
+            message = f'Error rasterizing {path} for tile {tile} on second try.'
             self.__end_tracking(id, tile=tile, message=message)
             return None
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
         'morecantile >= 3.1, < 4',
         'Rtree >= 0.9, < 1',
         'rasterio >= 1.2, < 2',
-        'pdgstaging @ git+https://github.com/PermafrostDiscoveryGateway/viz-staging.git#egg=pdgstaging',
         'colormaps @ git+https://github.com/pratiman-91/colormaps.git#egg=colormaps'
     ],
     python_requires='>=3.9, <4',


### PR DESCRIPTION
For each staged file that fails to rasterize, log the error and try one more time with the same approach, rasterize_vector(). Meant to catch unnecessary errors in rasterization step because some staged files that error are not corrupt. See issue #7 